### PR TITLE
fix a typo system-tray.md

### DIFF
--- a/docs/guides/system-tray.md
+++ b/docs/guides/system-tray.md
@@ -178,7 +178,7 @@ fn main() {
 Note that `tauri::Icon` must be a `Path` variant on Linux, and `Raw` variant on Windows and macOS.
 
 ```rust
-app.tray_handle().set_icon(tauri::Icon::Raw(include_bytes!("../path/to/myicon.ico"))).unwrap();
+app.tray_handle().set_icon(tauri::TrayIcon::Raw(include_bytes!("../path/to/myicon.ico"))).unwrap();
 ```
 
 [Template Image]: https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc


### PR DESCRIPTION
Updating tray icon: tauri::Icon haș to be tauri::TrayIcon